### PR TITLE
Build and then use action to deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,25 @@ jobs:
       run: |
         sudo apt --assume-yes update
         sudo apt --assume-yes install git
-    # Deploy the website (site based on Docusaurus v2). 
+    # Build the website (site based on Docusaurus v2). 
     # Do build explicitly since it has a custom script. yarn deploy would not invoke custom script
-    # Then deploy by skipping the build
-    - name: Deploying Libra Lip Website to GitHub Pages
+    - name: Build website which includes custom script for lips in /scripts
+    run: |
+      yarn install
+      yarn build
+    # Then deploy using the build directory
+    # Could possibly use the --skip-build option for deploy when upgrading Docusaurus
+    # beyond alpha-.50
+    # Something like this might work:
+    #   yarn && yarn build && GIT_USER=libra-doc-bot USE_SSH=false yarn deploy --skip-build
+    - name: Set up GitHub credentials to have the bot doing the commit
       run: |
         git config --global user.email "libra-doc-bot@users.noreply.github.com"
         git config --global user.name "Libra Lip Website Deployment Script"
         echo "machine github.com login libra-doc-bot password ${{ secrets.PUBLISH_AND_DEPLOY_TOKEN }}" > ~/.netrc
-        yarn && yarn build && GIT_USER=libra-doc-bot USE_SSH=false yarn deploy --skip-build
+    - name: Deploying Libra Lip Website to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+      with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: build # The folder the action should deploy.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       yarn build
     # Then deploy using the build directory
     # Could possibly use the --skip-build option for deploy when upgrading Docusaurus
-    # beyond alpha-.50
+    # to alpha-0.56 or beyond
     # Something like this might work:
     #   yarn && yarn build && GIT_USER=libra-doc-bot USE_SSH=false yarn deploy --skip-build
     - name: Set up GitHub credentials to have the bot doing the commit


### PR DESCRIPTION
Will change this to `yarn deploy --skip-build` wehen we updrade Docusaurus to at least 0.56