### PR TITLE
Update LIPs with transaction metadata and Travel Rule info

### DIFF
--- a/lips/lip-1.mdx
+++ b/lips/lip-1.mdx
@@ -521,7 +521,7 @@ dual_attest_msg = libra.TransactionArgument__U8Vector(bytes(dual_attest_msg_byte
 dual_attest_msg_lcs = lcs.serialize(dual_attest_msg, libra.TransactionArgument__U8Vector)
 
 // We sign the bytes LCS bytes directly with the compliance private key
-// This is encode_peer_to_peer_with_metadata_script() 'metadata_signature' parameter
+// `receiver_metadata_signature` will be used as the `metadata_signature` parameter in  encode_peer_to_peer_with_metadata_script()
 receiver_metadata_signature = compliance_private_key.sign(dual_attest_msg_lcs)
 ```
 

--- a/lips/lip-1.mdx
+++ b/lips/lip-1.mdx
@@ -531,9 +531,14 @@ The `receiver_metadata_signature` will then be placed into the `recipient_signat
 Once both sender and receiver have a status of 'ready_for_settlement', the transaction may then be submitted on-chain by the sender VASP. This submission will utilize the `recipient_signature` which was provided by the receiver VASP (generated via [Recipient Signature](#recipient-signature).  The sender VASP will now generate a transaction via the following and then submit the transaction on-chain:
 
 ```
+use libra_types::transaction::{
+    RawTransaction,
+    metadata::{Metadata, TravelRuleMetadata, TravelRuleMetadataV0}
+};
+
 metadata = Metadata::TravelRuleMetadata(
   TravelRuleMetadata::TravelRuleMetadataVersion0(
-    TravelRuleMetadatav0 {
+    TravelRuleMetadataV0 {
       off_chain_reference_id: "123abc", /* The off-chain reference ID specified by `reference_id` in the Off-chain APIs */
 }));
 

--- a/lips/lip-1.mdx
+++ b/lips/lip-1.mdx
@@ -494,14 +494,35 @@ A state of `pending_review` may be set to indicate a manual review is taking pla
 In the event of a soft match, the VASP associated with this actor will need to determine what next steps are required, and if it decides to send additional KYC information to clear the soft-match does so via the KYCObject field of additional_kyc_data. After human review of this data, this state may result in any of ready_for_settlement or abort (abort if the soft-match was unable to be cleared). If data is not received within a reasonable SLA (suggested to be 24 hours), this state will result in abort. The VASP providing the additional KYC data is also allowed to abort the transaction at any point if they do not have additional KYC data or do not wish to supply it.
 
 # Recipient Signature
-Once the recipient side is comfortable that it has received appropriate information and is ready for the transaction to go on-chain, the recipient side will provide their signature in order to support dual attestation. The receiver VASP will sign with the receiver compliance private key:
-
+Once the recipient side is comfortable that it has received appropriate information and is ready for the transaction to go on-chain, the recipient side will provide their signature in order to support dual attestation. The receiver VASP will sign with the receiver compliance private key, here is a concrete example of how to generate the Travel Rule dual attestation signable and recipient signature using Libra Python Client SDK:
 ```
-metadata = TravelRuleMetadatav0 {
-  off_chain_reference_id: "123abc", /* The off-chain reference ID specified by `reference_id` in the Off-chain APIs */
-};
-receiver_lcs_data = lcs(metadata, sender_address /* raw on-chain address (https://github.com/libra/lip/blob/master/lips/lip-5.md#terminology) */, amount, "@@$$LIBRA_ATTEST$$@@" /*ASCII-encoded string*/);
-recipient_signature = sign(receiver_lcs_data, receiver_compliance_private_key /* key used to sign */);
+from pylibra import lcs
+from pylibra import libra_types as libra
+from pylibra import serde_types as st
+...
+
+metadata: Metadata = libra.Metadata__TravelRuleMetadata(
+  libra.TravelRuleMetadata__TravelRuleMetadataVersion0(
+    libra.TravelRuleMetadataV0(
+      off_chain_reference_id="reference_id",
+    )
+  )
+)
+// This is encode_peer_to_peer_with_metadata_script() 'metadata' parameter
+lcs_metadata = lcs.serialize(metadata, libra.Metadata)
+
+dual_attest_msg_bytes: bytearray = bytearray()
+dual_attest_msg_bytes.extend(lcs_metadata)  # Travel Rule metadata
+dual_attest_msg_bytes.extend(lcs.serialize(bytes.fromhex("793251de1a61e9b4d1a17d13aa015e45"), bytes))  # Raw on-chain address (https://github.com/libra/lip/blob/master/lips/lip-5.md#terminology)
+dual_attest_msg_bytes.extend(lcs.serialize(st.uint64(1000000), st.uint64))  # Amount
+dual_attest_msg_bytes.extend(lcs.serialize(b"@@$$LIBRA_ATTEST$$@@", bytes))  # ASCII-encoded Libra Domain Separator string
+
+dual_attest_msg = libra.TransactionArgument__U8Vector(bytes(dual_attest_msg_bytes))
+dual_attest_msg_lcs = lcs.serialize(dual_attest_msg, libra.TransactionArgument__U8Vector)
+
+// We sign the bytes LCS bytes directly with the compliance private key
+// This is encode_peer_to_peer_with_metadata_script() 'metadata_signature' parameter
+receiver_metadata_signature = compliance_private_key.sign(dual_attest_msg_lcs)
 ```
 
 The `receiver_metadata_signature` will then be placed into the `recipient_signature` field of the PaymentObject in the off-chain API, thus providing it to the sender so that the sender VASP may submit the transaction on-chain.
@@ -510,12 +531,14 @@ The `receiver_metadata_signature` will then be placed into the `recipient_signat
 Once both sender and receiver have a status of 'ready_for_settlement', the transaction may then be submitted on-chain by the sender VASP. This submission will utilize the `recipient_signature` which was provided by the receiver VASP (generated via [Recipient Signature](#recipient-signature).  The sender VASP will now generate a transaction via the following and then submit the transaction on-chain:
 
 ```
-metadata = TravelRuleMetadatav0 {
-  off_chain_reference_id: "123abc", /* The off-chain reference ID specified by `reference_id` in the Off-chain APIs */
-};
+metadata = Metadata::TravelRuleMetadata(
+  TravelRuleMetadata::TravelRuleMetadataVersion0(
+    TravelRuleMetadatav0 {
+      off_chain_reference_id: "123abc", /* The off-chain reference ID specified by `reference_id` in the Off-chain APIs */
+}));
 
-lcs_metadata = lcs(MetadataType::TravelRuleMetadataType(
-        TravelRuleMetadata::TravelRuleMetadataVersion0(metadata))),
+
+lcs_metadata = lcs.serialize(metadata, Metadata);
 
 program = encode_peer_to_peer_with_metadata_script(
     "LBR" /*currency*/,

--- a/lips/lip-1.mdx
+++ b/lips/lip-1.mdx
@@ -508,7 +508,7 @@ metadata: Metadata = libra.Metadata__TravelRuleMetadata(
     )
   )
 )
-// This is encode_peer_to_peer_with_metadata_script() 'metadata' parameter
+// `lcs_metadata` will be used as the `metadata` parameter in encode_peer_to_peer_with_metadata_script()
 lcs_metadata = lcs.serialize(metadata, libra.Metadata)
 
 dual_attest_msg_bytes: bytearray = bytearray()

--- a/lips/lip-1.mdx
+++ b/lips/lip-1.mdx
@@ -494,7 +494,7 @@ A state of `pending_review` may be set to indicate a manual review is taking pla
 In the event of a soft match, the VASP associated with this actor will need to determine what next steps are required, and if it decides to send additional KYC information to clear the soft-match does so via the KYCObject field of additional_kyc_data. After human review of this data, this state may result in any of ready_for_settlement or abort (abort if the soft-match was unable to be cleared). If data is not received within a reasonable SLA (suggested to be 24 hours), this state will result in abort. The VASP providing the additional KYC data is also allowed to abort the transaction at any point if they do not have additional KYC data or do not wish to supply it.
 
 # Recipient Signature
-Once the recipient side is comfortable that it has received appropriate information and is ready for the transaction to go on-chain, the recipient side will provide their signature in order to support dual attestation. The receiver VASP will sign with the receiver compliance private key, here is a concrete example of how to generate the Travel Rule dual attestation signable and recipient signature using Libra Python Client SDK:
+Once the recipient side is comfortable that it has received appropriate information and is ready for the transaction to go on-chain, the recipient side will provide their signature in order to support dual attestation. The receiver VASP will sign with the receiver compliance private key. The following is a concrete example of how to generate the Travel Rule dual attestation signable and the recipient signature using Libra Python Client SDK:
 ```
 from pylibra import lcs
 from pylibra import libra_types as libra
@@ -567,4 +567,3 @@ The compliance processes described in this LIP are for informational purposes on
  
 # Copyright Notice
 This documentation is made available under the Creative Commons Attribution 4.0 International (CC BY 4.0) license (available at https://creativecommons.org/licenses/by/4.0/).
-

--- a/lips/lip-4.md
+++ b/lips/lip-4.md
@@ -58,10 +58,10 @@ struct GeneralMetadatav0 {
 
 // Used for versioning of travel rule metadata
 enum TravelRuleMetadata {
-    TravelRuleMetadataVersion0(TravelRuleMetadatav0),
+    TravelRuleMetadataVersion0(TravelRuleMetadataV0),
 }
 
-struct TravelRuleMetadatav0 {
+struct TravelRuleMetadataV0 {
     // Off-chain reference_id.  Used when off-chain APIs are used.
     // Specifies the off-chain reference ID that was agreed upon in off-chain APIs.
     Option<String> off_chain_reference_id,
@@ -188,7 +188,7 @@ User A who is on a custodial wallet (where the C wallet has a public address of 
 ```
 metadata = Metadata::TravelRuleMetadata(
   TravelRuleMetadata::TravelRuleMetadataVersion0(
-    TravelRuleMetadatav0 {
+    TravelRuleMetadataV0 {
       off_chain_reference_id: "123abc",
 }));
 

--- a/lips/lip-4.md
+++ b/lips/lip-4.md
@@ -30,14 +30,14 @@ Custodial wallets may want to identify specific users, such as merchants or indi
 
 # The Lifetime of a Transaction Containing Metadata
 
-The first step to submitting a transaction is producing the metadata. The sender first produces a *Libra Canonically Serialized (LCS)* metadata_wrapper consisting of an LCS-serialized MetadataType object:
+The first step to submitting a transaction is producing the metadata. The sender first produces a *Libra Canonically Serialized (LCS)* metadata_wrapper consisting of an LCS-serialized Metadata object:
 
 ```
-enum MetadataType {
+enum Metadata {
   Undefined,
-  GeneralMetadataType(GeneralMetadata),
-  TravelRuleMetadataType(TravelRuleMetadata),
-  UnstructuredBytesMetadataType(UnstructuredBytesMetadata),
+  GeneralMetadata(GeneralMetadata),
+  TravelRuleMetadata(TravelRuleMetadata),
+  UnstructuredBytesMetadata(UnstructuredBytesMetadata),
 }
 
 // Used for versioning of general metadata
@@ -78,7 +78,7 @@ Using the initial example described in the motivation, the merchant whose wallet
 
 ```
 0x01, 0x00, 01, "merch_a", 00, 00, 00
-/* general_metadata_type, general_metadata_v0,
+/* general_metadata, general_metadata_v0,
       to_subaddress_present, to_subaddress,
       from_subaddress_not_present,
       referenced_event_not_present */
@@ -107,16 +107,17 @@ For NC to NC transactions, there is no usage of subaddressing/metadata.
 User A (address 0x1234) on a NC wallet wishes to send 100 microlibra to merchant B who is on a private custodial wallet (where the custodial wallet has a public address of 0x7777 and the merchant has a sub-account of 'bob').  User A's client now composes a raw transaction with the following relevant fields:
 
 ```
-metadata = GeneralMetadatav0 {
-  to_subaddress: 'bob',
-};
+metadata = Metadata::GeneralMetadata(
+  GeneralMetadata::GeneralMetadaVersion0(
+    GeneralMetadataV0 {
+      to_subaddress: 'bob',
+})));
 
 program = encode_peer_to_peer_with_metadata_script(
     "LBR" /*currency*/,
     0x7777 /*recipient*/,
     100 /*amount*/,
-    lcs(MetadataType::GeneralMetadataType(
-        GeneralMetadata::GeneralMetadataVersion0(metadata))),
+    lcs.serialize(metadata, Metadata),
     None /*metadata_signature*/);
 
 RawTransaction {
@@ -130,16 +131,17 @@ RawTransaction {
 User A who is on a custodial wallet (where the C wallet has a public address of 0x7777 and user A has a sub-account of 'alice') wishes to send 100 microlibra to merchant B who is on a NC wallet (with an address of 0x1234).  User A's wallet then composes a transaction via:
 
 ```
-metadata = GeneralMetadatav0 {
-  from_subaddress: 'alice',
-};
+metadata = Metadata::GeneralMetadata(
+  GeneralMetadata::GeneralMetadaVersion0(
+    GeneralMetadataV0 {
+      from_subaddress: 'alice',
+})));
 
 program = encode_peer_to_peer_with_metadata_script(
     "LBR" /*currency*/,
     0x1234 /*recipient*/,
     100 /*amount*/,
-    lcs(MetadataType::GeneralMetadataType(
-        GeneralMetadata::GeneralMetadataVersion0(metadata))),
+    lcs.serialize(metadata, Metadata),
     None /*metadata_signature*/);
 
 RawTransaction {
@@ -154,17 +156,19 @@ RawTransaction {
 Merchant B now wishes to refund user A. But user A was sending from a custodial account so merchant B must send the funds back to the custodial account and include subaddress information so that the funds are directed back to user A.  Merchant B’s client now constructs a transaction via the following where referenced_event is the committed event sequence number under the sending account of the original sent payment event:
 
 ```
-metadata = GeneralMetadatav0 {
-  to_subaddress: 'alice',
-  referenced_event: 123,
-};
+metadata = Metadata::GeneralMetadata(
+  GeneralMetadata::GeneralMetadaVersion0(
+    GeneralMetadataV0 {
+      to_subaddress: 'alice',
+      referenced_event: 123,
+})));
+
 
 program = encode_peer_to_peer_with_metadata_script(
     "LBR" /*currency*/,
     0x7777 /*recipient*/,
     100 /*amount*/,
-    lcs(MetadataType::GeneralMetadataType(
-        GeneralMetadata::GeneralMetadataVersion0(metadata))),
+    lcs.serialize(metadata, Metadata),
     None /*metadata_signature*/);
 
 RawTransaction {
@@ -182,12 +186,14 @@ For transactions over the travel rule limit, custodial to custodial transactions
 User A who is on a custodial wallet (where the C wallet has a public address of 0x7777 and user A has a sub-account of 'alice') wishes to send 100 microlibra to merchant B who is on a C wallet (where the C wallet has a public address of 0x1234 and merchant B has a sub-account of 'bob').  User A's wallet then composes a transaction via (note that the to/from subaddresses are not included since they were shared via the off-chain API):
 
 ```
-metadata = TravelRuleMetadatav0 {
-  off_chain_reference_id: "123abc",
-};
+metadata = Metadata::TravelRuleMetadata(
+  TravelRuleMetadata::TravelRuleMetadataVersion0(
+    TravelRuleMetadatav0 {
+      off_chain_reference_id: "123abc",
+}));
 
-lcs_metadata = lcs(MetadataType::TravelRuleMetadataType(
-        TravelRuleMetadata::TravelRuleMetadataVersion0(metadata))),
+lcs_metadata = lcs.serialize(metadata, Metadata);
+
 
 // receiver_signature is passed to the sender via the off-chain APIs as per
 // https://github.com/libra/lip/blob/master/lips/lip-1.mdx#recipient-signature
@@ -204,5 +210,4 @@ RawTransaction {
     program: program,
 }
 ```
-
 


### PR DESCRIPTION
- Updated the LIPs 1 & 4 with the Metadata struct name changes
- LCS serialization takes a type argument in every client SDK
- Added a concrete pylibra-based example for the generation & signature of dual attestation payload. (let me know if we only want pseudo code for consistency)

Signed-off-by: Nassim Eddequiouaq <nass@fb.com>