### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,6 @@
+# Info about CODEOWNERS
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Global owners - the current maintainers
+# https://libra.org/en-US/blog/lip-maintainers/
+*   @dahliamalkhi @kphfb @sblackshear @davidiw @aching


### PR DESCRIPTION
Add a `CODEOWNERS` file to this repo in order to:

1. Show who the LIP maintainers currently are
2. Utilize in branch and pull request protection management